### PR TITLE
fix(cmd options): improve node detection

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -2,7 +2,7 @@
 
 var args = process.argv;
 
-if (/node$/.test(args[0])) {
+if (/node(\.exe)?$/.test(args[0])) {
   args = args.slice(2);
 }
 


### PR DESCRIPTION
The commit extends the regular expression
for checking the os specific node extension.
E.g.: node on Linux and node.exe on Windows
